### PR TITLE
SRE: garde-fou CI + audit liens + dependabot + runbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Gems Jekyll / GitHub Pages
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      jekyll:
+        patterns:
+          - "*"
+
+  # Actions utilisées par les workflows CI
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+# Garde-fou : le site est construit et vérifié avant toute mise en ligne.
+# GitHub Pages déploie automatiquement `main` — ce workflow échoue AVANT
+# qu'une erreur de build ou un lien interne cassé n'atteigne la prod.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & vérification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+
+      - name: Build (strict)
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --strict_front_matter --trace
+
+      - name: Install HTMLProofer
+        run: gem install html-proofer --version '~> 5.0'
+
+      - name: Vérifier les liens internes & images
+        run: |
+          htmlproofer ./_site \
+            --disable-external \
+            --checks Links,Images \
+            --ignore-missing-alt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           JEKYLL_ENV: production
           # Évite les limites de débit de l'API GitHub lors du fetch du thème distant.
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # jekyll-github-metadata a besoin du nom du dépôt (fourni d'office par Pages).
+          PAGES_REPO_NWO: ${{ github.repository }}
         run: bundle exec jekyll build --strict_front_matter --trace
 
       - name: Install HTMLProofer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
   build:
     name: Build & vérification
     runs-on: ubuntu-latest
+    env:
+      # Le Gemfile.lock du dépôt est désynchronisé du Gemfile ; on laisse
+      # bundler le réconcilier dans le runner plutôt que d'échouer en mode gelé.
+      BUNDLE_FROZEN: "false"
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +36,8 @@ jobs:
       - name: Build (strict)
         env:
           JEKYLL_ENV: production
+          # Évite les limites de débit de l'API GitHub lors du fetch du thème distant.
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec jekyll build --strict_front_matter --trace
 
       - name: Install HTMLProofer

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,40 @@
+name: Vérification des liens
+
+# Audit hebdomadaire des liens (internes résolus sur le domaine live + externes).
+# Les réseaux sociaux renvoient souvent 403/429 aux robots : on les accepte pour
+# éviter les faux positifs. En cas de lien réellement mort, une issue est ouverte.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1' # tous les lundis à 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Vérifier les liens
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --base https://www.ris-plongee.com
+            --accept 200,206,403,429
+            --exclude-mail
+            --max-retries 2
+            "*.markdown" "*.html"
+          fail: true
+
+      - name: Ouvrir une issue si des liens sont cassés
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: 🔗 Liens cassés détectés
+          content-filepath: ./lychee/out.md
+          labels: broken-links

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,91 @@
+# Runbook — ris-plongee.com
+
+Site vitrine du club (Jekyll + GitHub Pages). Ce document sert de référence
+d'exploitation : comment le site est publié, comment le dépanner, et de quoi il
+dépend.
+
+## Architecture en une ligne
+
+Site statique **Jekyll** → publié par **GitHub Pages** (build classique depuis
+la branche `main`) → servi via le CDN Fastly de GitHub sur le domaine
+**www.ris-plongee.com** (le domaine nu `ris-plongee.com` redirige vers `www`).
+
+## Cycle de publication
+
+1. Un commit arrive sur `main` (idéalement via une Pull Request).
+2. La CI (`.github/workflows/ci.yml`) construit le site et vérifie les liens
+   internes. **Si elle échoue, ne pas merger.**
+3. Une fois sur `main`, GitHub Pages reconstruit et met en ligne en ~1–2 min.
+4. `cache-control: max-age=600` → une page peut rester en cache 10 min côté CDN.
+
+> Il n'y a **pas** d'environnement de préproduction. La prévisualisation se fait
+> en local (voir plus bas). Toujours ouvrir une PR pour laisser la CI valider.
+
+## Prévisualiser en local
+
+```bash
+bundle install
+bundle exec jekyll serve   # http://localhost:4000
+```
+Ruby attendu : voir `.ruby-version`. En cas de souci de dépendances :
+`bundle update` (le `Gemfile.lock` n'est pas utilisé par GitHub Pages, qui
+utilise sa propre version épinglée de la gem `github-pages`).
+
+## Surveillance
+
+- **CI** — échoue sur tout build cassé / lien interne mort (bloquant sur PR).
+- **Liens** (`.github/workflows/links.yml`) — audit hebdomadaire ; ouvre une
+  issue `broken-links` si un lien externe est réellement mort.
+- **Disponibilité** — *à mettre en place* : un moniteur externe (UptimeRobot /
+  Better Stack, offre gratuite) sur `https://www.ris-plongee.com` avec :
+  - une vérification par mot-clé (« Baptême ») pour détecter une page blanche ;
+  - une alerte d'expiration du certificat TLS ;
+  - idéalement un second check sur le lien HelloAsso (tunnel d'inscription).
+
+## Playbook incident
+
+**Le site est down / renvoie une erreur**
+1. Vérifier l'état de GitHub Pages : https://www.githubstatus.com/
+2. Onglet **Actions** du dépôt : le dernier déploiement Pages a-t-il échoué ?
+3. Reproduire en local (`jekyll serve`). Si ça casse en local → bug de contenu.
+4. Correctif rapide : `git revert <commit fautif>` puis push sur `main`.
+
+**Une page s'affiche mal / lien cassé**
+1. Lancer la CI localement : `bundle exec jekyll build && \
+   gem install html-proofer && htmlproofer ./_site --disable-external`
+2. Corriger, ouvrir une PR, laisser la CI valider.
+
+**Le domaine ne répond plus**
+1. Vérifier l'expiration du domaine et les enregistrements DNS chez le
+   registraire (voir « Dépendances externes »).
+2. Vérifier que le fichier `CNAME` du dépôt contient bien `www.ris-plongee.com`.
+
+## Reprise après sinistre (DR)
+
+Le code est intégralement versionné dans Git → aucune perte de contenu possible
+tant que le dépôt GitHub existe. Les vrais points de défaillance uniques sont les
+**comptes externes**, pas le code :
+
+| Dépendance | Rôle | Point de vigilance |
+|---|---|---|
+| Dépôt GitHub `RisPlongee/ris-plongee` | code + hébergement Pages | garder ≥ 2 admins |
+| Domaine `ris-plongee.com` | nom de domaine | **renouvellement** (auto-renew ?) |
+| DNS | pointage vers GitHub Pages | enregistrements A/CNAME |
+| Boîte `risplongee@gmail.com` | contact + agenda + réseaux | récupération / 2FA |
+| HelloAsso (`asrp-ris-plongee`) | inscriptions baptême | tunnel critique |
+| Google Maps / Agenda, YouTube, Instagram, Facebook, WhatsApp | embeds | comptes club |
+
+> **À compléter par un responsable** : qui détient chaque compte, où est géré le
+> renouvellement du domaine, et où sont stockés les accès (gestionnaire de mots
+> de passe partagé recommandé).
+
+## Actions à réaliser côté propriétaire (droits admin requis)
+
+Ces réglages ne peuvent pas être faits par PR — un admin du dépôt doit les
+activer dans les *Settings* :
+
+- [ ] **Forcer HTTPS** : Settings → Pages → cocher « Enforce HTTPS »
+      (actuellement désactivé).
+- [ ] **Protéger `main`** : Settings → Branches → exiger le passage de la CI et
+      une PR avant merge.
+- [ ] **Moniteur de disponibilité** externe (cf. section Surveillance).


### PR DESCRIPTION
## Problème

Le site se déploie **automatiquement depuis `main` sans aucune validation** : un push qui casse le build ou introduit un lien interne mort part directement en production, sans filet ni alerte. Il n'y a par ailleurs aucune surveillance ni documentation d'exploitation.

Cette PR ajoute les garde-fous de fiabilité **sans changer le mode de déploiement** (GitHub Pages continue de publier `main`).

## Ce que ça ajoute

### 1. Garde-fou CI — `.github/workflows/ci.yml`
Sur **chaque PR et push sur `main`** : build strict (`jekyll build --strict_front_matter`) + `html-proofer` (liens internes & images). Un build cassé ou un lien interne mort **échoue avant** d'atteindre la prod.
→ Pour que ce soit réellement bloquant : *Settings → Branches → Protect `main`* (exiger la CI + une PR). Voir le runbook.

### 2. Audit des liens — `.github/workflows/links.yml`
`lychee` **hebdomadaire** (+ déclenchement manuel) sur les liens internes (résolus sur le domaine live) et externes. Tolérant aux **403/429** que les réseaux sociaux renvoient aux robots (pas de faux positifs), et **ouvre une issue `broken-links`** si un lien est réellement mort (HelloAsso déplacé, page FB supprimée, etc.).

### 3. Hygiène des dépendances — `.github/dependabot.yml`
Mises à jour hebdomadaires groupées pour **bundler** (gems Jekyll) et **github-actions** (versions des actions CI). Répond aux alertes de vulnérabilités du dépôt.

### 4. Runbook d'exploitation — `RUNBOOK.md`
Architecture, cycle de publication, prévisualisation locale, **playbook incident** (site down / page cassée / domaine muet), **reprise après sinistre** (les vrais SPOF sont les *comptes externes* — domaine, DNS, gmail, HelloAsso — pas le code), et la checklist des **actions admin**.

## Actions restantes côté admin (impossibles par PR)

- [ ] **Forcer HTTPS** : Settings → Pages → « Enforce HTTPS » — *actuellement désactivé* (`https_enforced: false`).
- [ ] **Protéger `main`** : exiger le passage de la CI avant merge (rend le garde-fou #1 bloquant).
- [ ] **Moniteur de disponibilité** externe (UptimeRobot/Better Stack, gratuit) : home + mot-clé « Baptême » + lien HelloAsso.

## Notes de validation

> Workflows YAML et `dependabot.yml` validés. Je n'ai pas pu exécuter la CI en local (Ruby système en 2.6). Au premier run, `html-proofer` pourrait signaler des liens internes déjà cassés sur le site actuel — c'est précisément le rôle du garde-fou ; corriger le cas échéant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)