### PR TITLE
design(nav): favicon du club à la place de l'emoji masque

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,7 @@
 <header class="nav">
   <a class="brand" href="/">
-    <span class="mark">🤿</span>
+    <img class="mark" src="/assets/img/favicon/favicon-96x96.png" width="34" height="34" alt="">
+
     <span>RIS PLONGÉE<small>Ris-Orangis · Essonne</small></span>
   </a>
   <nav class="links" aria-label="Navigation principale">

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -84,6 +84,7 @@ header.nav {
 }
 .brand { display: flex; align-items: center; gap: 0.6rem; font-family: var(--display); font-weight: 800; letter-spacing: 0.02em; color: var(--foam); text-decoration: none; }
 .brand .mark { display: inline-grid; place-items: center; width: 34px; height: 34px; border-radius: 50%; border: 2px solid var(--surface); color: var(--surface); font-size: 1rem; }
+.brand img.mark { border: none; border-radius: 0; object-fit: contain; background: transparent; }
 .brand small { display: block; font-weight: 500; font-size: 0.62rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--foam-dim); }
 nav.links { display: flex; align-items: center; gap: clamp(0.6rem, 2vw, 1.6rem); }
 nav.links a { color: var(--foam); text-decoration: none; font-size: 0.86rem; font-weight: 600; letter-spacing: 0.01em; opacity: 0.86; }


### PR DESCRIPTION
Dans la barre de navigation, remplace l'emoji 🤿 par le **favicon du club** (`favicon-96x96.png`, 34px) à côté de « RIS PLONGÉE ».

- Suppression du cercle bordé cyan qui encadrait l'emoji ; le logo s'affiche en `object-fit: contain`.
- `width`/`height` fixés (pas de décalage de mise en page).
- `alt=""` : le texte « RIS PLONGÉE » juste à côté porte déjà l'information (évite la redondance pour les lecteurs d'écran).

> Ce changement était parti par erreur sur la branche `redesign/la-descente` **après** son merge — il n'était donc pas sur `main`. Cette PR le rapatrie proprement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)