### PR TITLE
SEO : données structurées locales, FAQ et image de partage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - RUNBOOK.md
 
 plugins:
   - jekyll-seo-tag
@@ -23,9 +24,40 @@ email: risplongee+website@gmail.com
 url: https://www.ris-plongee.com
 description: "Découvrez la passion de la plongée avec Ris-plongée à Ris-Orangis, dans le département de l'Essonne. Des baptêmes gratuits chaque mercredi soir et des sorties en mer vous attendent. Rejoignez-nous dès aujourd'hui pour une aventure inoubliable !"
 
+# Image de partage social (Open Graph / Twitter) — reprise par jekyll-seo-tag
+image: /assets/img/cover.jpg
+twitter:
+  card: summary_large_image
+
 social_links:
   Facebook: https://www.facebook.com/people/Ris-Plong%C3%A9e/pfbid081pvEYLc6cwrZXcnRv3nUq4jxbg2M18ahQA9adH7wRayQ1TBccToxqnR74VJpqENl/
   Instagram: https://www.instagram.com/risplongee/
+
+# Profils officiels du club — alimentent le "sameAs" des données structurées
+same_as:
+  - https://www.facebook.com/people/Ris-Plong%C3%A9e/pfbid081pvEYLc6cwrZXcnRv3nUq4jxbg2M18ahQA9adH7wRayQ1TBccToxqnR74VJpqENl/
+  - https://www.instagram.com/risplongee/
+  - https://www.youtube.com/@RisPlongee
+
+# Faits du club — alimentent le JSON-LD SportsClub (SEO local)
+club:
+  sport: Plongée sous-marine
+  founding_year: 1970
+  price_range: "≈ 200 € / an"
+  address:
+    street: Piscine René Touzin
+    locality: Ris-Orangis
+    postal_code: "91130"
+    region: Essonne
+    country: FR
+  geo:
+    lat: 48.6470276
+    lng: 2.4038455
+  affiliations:
+    - name: FFESSM
+      url: https://www.ffessm.fr/
+    - name: FSGT
+      url: https://www.fsgt.org/
 
 seo_description_max_words: 200
 

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -1,0 +1,20 @@
+# Questions fréquentes — source unique de la section visible ET du JSON-LD FAQPage.
+# Les réponses doivent rester factuelles et cohérentes avec le reste du site.
+
+- q: "Le baptême de plongée est-il vraiment gratuit ?"
+  a: "Oui. Chaque mercredi soir à la piscine René Touzin de Ris-Orangis, nous proposons un baptême de plongée gratuit et sans engagement. Aucun matériel ni aucune expérience n'est requis : nous prêtons tout l'équipement et un moniteur vous accompagne dans l'eau. Il suffit de réserver un créneau via HelloAsso."
+
+- q: "Combien coûte l'adhésion annuelle au club ?"
+  a: "Environ 200 € par an, l'une des adhésions les plus abordables de France. Ce tarif comprend l'accès à la piscine René Touzin 2h par semaine, une fosse de 20 m chaque mois, les formations encadrées (PE20/PE40, PA20/PA40/PA60), les sorties du club, ainsi que l'adhésion FFESSM ou FSGT avec l'assurance plongée."
+
+- q: "Où et quand ont lieu les entraînements ?"
+  a: "Tous les mercredis, hors vacances scolaires, de 20h à 22h à la piscine René Touzin, à Ris-Orangis dans l'Essonne. De 22h à 23h, on se retrouve au club-house juste à côté pour un moment convivial."
+
+- q: "Quelles formations et niveaux de plongée propose Ris Plongée ?"
+  a: "Le club forme du premier baptême jusqu'au Niveau 4, avec des certifications FFESSM/FSGT reconnues dans le monde entier : Plongeur encadré PE20 et PE40, puis Plongeur autonome PA20, PA40 et PA60. La progression se fait à votre rythme, la sécurité d'abord."
+
+- q: "Faut-il posséder son propre matériel pour commencer ?"
+  a: "Non. Le club dispose de tout l'équipement nécessaire et le prête aux débutants. Nous vous conseillons ensuite pour choisir votre propre matériel quand vous le souhaitez."
+
+- q: "Où se situe le club de plongée Ris Plongée ?"
+  a: "À Ris-Orangis, dans le département de l'Essonne (91), à la piscine René Touzin. Le club, association loi 1901 créée en 1970, est affilié à la FFESSM et à la FSGT."

--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -1,0 +1,34 @@
+<section class="band" id="faq">
+  <div class="container">
+    <div class="sec-head reveal">
+      <span class="depth">? · avant de plonger</span>
+      <div>
+        <h2>Questions fréquentes</h2>
+        <p>Tout ce qu'on nous demande avant un premier baptême.</p>
+      </div>
+    </div>
+    <div class="faq reveal">
+      {%- for item in site.data.faq -%}
+      <details class="faq-item">
+        <summary>{{ item.q }}</summary>
+        <div class="faq-a"><p>{{ item.a }}</p></div>
+      </details>
+      {%- endfor -%}
+    </div>
+  </div>
+</section>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {%- for item in site.data.faq -%}
+    {
+      "@type": "Question",
+      "name": {{ item.q | jsonify }},
+      "acceptedAnswer": { "@type": "Answer", "text": {{ item.a | jsonify }} }
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
 <meta name="theme-color" content="#05263A">
 
 {% seo %}
+{% include schema.html %}
 
 <link rel="icon" href="/assets/img/favicon/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/assets/img/favicon/favicon-96x96.png" sizes="96x96" type="image/png">

--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -1,0 +1,62 @@
+{%- comment -%}
+Données structurées du club (SEO local). Complète le noeud WebSite déjà émis par
+jekyll-seo-tag : adresse, géolocalisation, horaires, affiliations, offre "baptême
+gratuit" et profils sociaux (sameAs). Les valeurs proviennent de _config.yml.
+{%- endcomment -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SportsClub",
+  "@id": "{{ site.url }}/#club",
+  "name": {{ site.title | jsonify }},
+  "alternateName": {{ site.author | jsonify }},
+  "description": {{ site.description | jsonify }},
+  "url": "{{ site.url }}/",
+  "logo": "{{ site.url }}{{ site.logo }}",
+  "image": "{{ site.url }}{{ site.image }}",
+  "email": {{ site.email | jsonify }},
+  "sport": {{ site.club.sport | jsonify }},
+  "foundingDate": "{{ site.club.founding_year }}",
+  "priceRange": {{ site.club.price_range | jsonify }},
+  "areaServed": { "@type": "AdministrativeArea", "name": {{ site.club.address.region | jsonify }} },
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": {{ site.club.address.street | jsonify }},
+    "addressLocality": {{ site.club.address.locality | jsonify }},
+    "postalCode": {{ site.club.address.postal_code | jsonify }},
+    "addressRegion": {{ site.club.address.region | jsonify }},
+    "addressCountry": {{ site.club.address.country | jsonify }}
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": {{ site.club.geo.lat }},
+    "longitude": {{ site.club.geo.lng }}
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Wednesday",
+      "opens": "20:00",
+      "closes": "23:00"
+    }
+  ],
+  "makesOffer": {
+    "@type": "Offer",
+    "name": "Baptême de plongée gratuit",
+    "price": "0",
+    "priceCurrency": "EUR",
+    "url": {{ site.call_to_action.url | jsonify }},
+    "availability": "https://schema.org/InStock"
+  },
+  "memberOf": [
+    {%- for a in site.club.affiliations -%}
+    { "@type": "Organization", "name": {{ a.name | jsonify }}, "url": {{ a.url | jsonify }} }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ],
+  "sameAs": [
+    {%- for url in site.same_as -%}
+    {{ url | jsonify }}{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -194,6 +194,17 @@ section.band { padding-block: clamp(3.5rem, 10vh, 7rem); }
 .social { display: inline-flex; align-items: center; gap: 0.55rem; text-decoration: none; color: var(--foam); background: rgba(233,244,243,0.06); border: 1px solid rgba(233,244,243,0.14); border-radius: 999px; padding: 0.6rem 1.1rem; font-weight: 600; font-size: 0.9rem; }
 .social:hover, .social:focus-visible { border-color: var(--surface); color: var(--surface); }
 
+/* FAQ */
+.faq { display: grid; gap: 0.7rem; }
+.faq-item { background: rgba(233,244,243,0.05); border: 1px solid rgba(233,244,243,0.12); border-radius: 14px; padding: 0 1.2rem; }
+.faq-item summary { list-style: none; cursor: pointer; font-family: var(--display); font-weight: 700; font-size: 1.02rem; color: var(--foam); padding: 1.1rem 0; display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+.faq-item summary::-webkit-details-marker { display: none; }
+.faq-item summary::after { content: "+"; color: var(--coral); font-weight: 800; font-size: 1.5rem; line-height: 1; transition: transform .2s ease; }
+@media (prefers-reduced-motion: reduce) { .faq-item summary::after { transition: none; } }
+.faq-item[open] summary::after { transform: rotate(45deg); }
+.faq-a { padding: 0 0 1.1rem; }
+.faq-a p { margin: 0; color: var(--foam-dim); font-size: 0.98rem; max-width: 64ch; }
+
 /* final CTA */
 .final { text-align: center; padding-block: clamp(4rem, 12vh, 8rem); }
 .final h2 { font-family: var(--display); font-weight: 800; font-size: clamp(2rem, 6vw, 3.6rem); line-height: 1; letter-spacing: -0.02em; margin: 0 auto 1rem; max-width: 18ch; text-wrap: balance; }

--- a/index.markdown
+++ b/index.markdown
@@ -52,7 +52,7 @@ description: "Ris Plongée, club associatif de plongée sous-marine à Ris-Orang
       <span class="depth">-6 m · le club</span>
       <div>
         <h2>Une famille de plongeurs depuis 1970</h2>
-        <p>Chaque mercredi, on s'entraîne, on progresse — puis on refait le monde au club-house autour d'un verre. C'est ça, Ris Plongée.</p>
+        <p>Chaque mercredi, on s'entraîne, on progresse — puis on refait le monde au club-house autour d'un verre. C'est ça, Ris Plongée. <a href="/club.html">Découvrir la vie du club</a>.</p>
       </div>
     </div>
     <div class="cards reveal" style="margin-bottom:1.5rem;">
@@ -76,7 +76,7 @@ description: "Ris Plongée, club associatif de plongée sous-marine à Ris-Orang
       <span class="depth">-20 m · la fosse</span>
       <div>
         <h2>Des formations reconnues, du premier souffle au N4</h2>
-        <p>Certifications FFESSM / FSGT valables dans le monde entier. On avance à votre rythme, la sécurité d'abord.</p>
+        <p>Certifications FFESSM / FSGT valables dans le monde entier. On avance à votre rythme, la sécurité d'abord. <a href="/details.html">Où commencer la plongée en Essonne&nbsp;?</a></p>
       </div>
     </div>
     <div class="cards reveal" style="margin-bottom:1.5rem;">
@@ -142,6 +142,8 @@ description: "Ris Plongée, club associatif de plongée sous-marine à Ris-Orang
     </div>
   </div>
 </section>
+
+{% include faq.html %}
 
 <section class="final">
   <div class="container">


### PR DESCRIPTION
## Objectif
Booster le référencement (surtout **local**) sans toucher au design. Base déjà saine (`jekyll-seo-tag`, sitemap, robots, titres ciblés, lazy-loading, façades d'embed). Leviers manquants, par ordre d'impact.

## Changements
### 🔴 Données structurées locales — `SportsClub` JSON-LD
`_includes/schema.html` (via `_config.yml`) : adresse, géo, horaires (mercredi 20h–23h), tarif, affiliations FFESSM/FSGT, offre « baptême gratuit », `sameAs`. Signal clé du **pack local Google**. Complète le nœud `WebSite` de jekyll-seo-tag.

### 🟠 FAQ + `FAQPage` JSON-LD
`_data/faq.yml` = source unique affichage + schéma. 6 Q/R fondées sur le contenu existant. Accordéon `<details>` natif, sans JS. Longue traîne + rich snippets.

### 🟠 Image de partage social
`og:image` + `twitter:card=summary_large_image` (`cover.jpg`). Avant : aucune image.

### 🟠 `RUNBOOK.md` exclu du build
Doc interne qui était indexé + dans le sitemap. Reste dans le repo, plus publié.

### 🟢 Maillage interne
Deux liens contextuels home → `/club` et `/details`.

## Vérification
JSON-LD validé comme JSON strict (rendu Liquid simulé). Build local impossible (toolchain Ruby) → CI GitHub Pages valide.

## À valider après merge
- [Test résultats enrichis Google](https://search.google.com/test/rich-results) sur les 2 blocs.
- Fiche **Google Business Profile** (NAP cohérent) — plus gros levier local restant, hors site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
